### PR TITLE
Use sqlite3 for development

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,10 +4,8 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
 development:
-  adapter: postgresql
-  database: det_sker
-  username: det_sker
-  password: det_sker
+  adapter: sqlite3
+  database: db/development.sqlite3
   pool: 5
   timeout: 5000
 


### PR DESCRIPTION
@ronan-mch couldn't get Postgres up and running in less than 2 minutes.

The problem with sqlite3 is that running `db:migrate` will alter `db/schema.rb` - do you know why? It removes `using: btree` from all fields...

```
diff --git a/db/schema.rb b/db/schema.rb
index dedcc32..26a9960 100644
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,9 +13,6 @@
 
 ActiveRecord::Schema.define(version: 20151121214109) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
   create_table "categories", force: :cascade do |t|
     t.string   "danish",     limit: 255
     t.string   "english",    limit: 255
@@ -23,24 +20,24 @@ ActiveRecord::Schema.define(version: 20151121214109) do
     t.datetime "updated_at"
   end
 
-  add_index "categories", ["danish"], name: "index_categories_on_danish", unique: true, using: :btree
-  add_index "categories", ["english"], name: "index_categories_on_english", unique: true, using: :btree
+  add_index "categories", ["danish"], name: "index_categories_on_danish", unique: true
+  add_index "categories", ["english"], name: "index_categories_on_english", unique: true
 
   create_table "categories_event_series", id: false, force: :cascade do |t|
     t.integer "event_series_id"
     t.integer "category_id"
   end
 
-  add_index "categories_event_series", ["category_id"], name: "index_categories_event_series_on_category_id", using: :btree
-  add_index "categories_event_series", ["event_series_id"], name: "index_categories_event_series_on_event_series_id", using: :btree
+  add_index "categories_event_series", ["category_id"], name: "index_categories_event_series_on_category_id"
+  add_index "categories_event_series", ["event_series_id"], name: "index_categories_event_series_on_event_series_id"
```

